### PR TITLE
Change source and target to Java versions to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The plugin compiles fine with JDK 1.7 and does not seem to use any 1.8-only syntax/functionailty, as far as I can see. It runs just fine when compiled with JDK 1.7 as well. Maven failed when building this plugin on Ubuntu 14.04, as only OpenJDK 1.7 was installed; 1.8 is not yet available in the Ubuntu package repositories. Updating pom.xml to allow for compilation with JDK 1.7.
